### PR TITLE
Revert "Revert "DispSync: workaround HH hardware vsync issue""

### DIFF
--- a/services/surfaceflinger/Android.mk
+++ b/services/surfaceflinger/Android.mk
@@ -86,6 +86,10 @@ ifeq ($(TARGET_RUNNING_WITHOUT_SYNC_FRAMEWORK),true)
     LOCAL_CFLAGS += -DRUNNING_WITHOUT_SYNC_FRAMEWORK
 endif
 
+ifeq ($(TARGET_HAS_HH_VSYNC_ISSUE),true)
+    LOCAL_CFLAGS += -DHH_VSYNC_ISSUE
+endif
+
 # See build/target/board/generic/BoardConfig.mk for a description of this setting.
 ifneq ($(VSYNC_EVENT_PHASE_OFFSET_NS),)
     LOCAL_CFLAGS += -DVSYNC_EVENT_PHASE_OFFSET_NS=$(VSYNC_EVENT_PHASE_OFFSET_NS)

--- a/services/surfaceflinger/DispSync.cpp
+++ b/services/surfaceflinger/DispSync.cpp
@@ -419,6 +419,9 @@ void DispSync::reset() {
     mNumResyncSamples = 0;
     mFirstResyncSample = 0;
     mNumResyncSamplesSincePresent = 0;
+#ifdef HH_VSYNC_ISSUE
+    mNumPresentWithoutResyncSamples = 0;
+#endif
     resetErrorLocked();
 }
 
@@ -443,6 +446,17 @@ bool DispSync::addPresentFence(const sp<Fence>& fence) {
 
     updateErrorLocked();
 
+#ifdef HH_VSYNC_ISSUE
+    // This is a workaround for b/25845510.
+    // If we have no resync samples after many presents, something is wrong with
+    // HW vsync. Tell SF to disable HW vsync now and re-enable it next time.
+    if (mNumResyncSamples == 0 &&
+        mNumPresentWithoutResyncSamples++ > MAX_PRESENT_WITHOUT_RESYNC_SAMPLES) {
+        mNumPresentWithoutResyncSamples = 0;
+        return false;
+    }
+#endif
+
     return !mModelUpdated || mError > kErrorThreshold;
 }
 
@@ -451,6 +465,9 @@ void DispSync::beginResync() {
     ALOGV("[%s] beginResync", mName);
     mModelUpdated = false;
     mNumResyncSamples = 0;
+#ifdef HH_VSYNC_ISSUE
+    mNumPresentWithoutResyncSamples = 0;
+#endif
 }
 
 bool DispSync::addResyncSample(nsecs_t timestamp) {

--- a/services/surfaceflinger/DispSync.h
+++ b/services/surfaceflinger/DispSync.h
@@ -138,6 +138,9 @@ private:
     enum { MIN_RESYNC_SAMPLES_FOR_UPDATE = 6 };
     enum { NUM_PRESENT_SAMPLES = 8 };
     enum { MAX_RESYNC_SAMPLES_WITHOUT_PRESENT = 4 };
+#ifdef HH_VSYNC_ISSUE
+    enum { MAX_PRESENT_WITHOUT_RESYNC_SAMPLES = 8 };
+#endif
 
     const char* const mName;
 
@@ -168,6 +171,9 @@ private:
     size_t mFirstResyncSample;
     size_t mNumResyncSamples;
     int mNumResyncSamplesSincePresent;
+#ifdef HH_VSYNC_ISSUE
+    int mNumPresentWithoutResyncSamples;
+#endif
 
     // These member variables store information about the present fences used
     // to validate the currently computed model.


### PR DESCRIPTION
This might be still needed on HH flavors.

This reverts commit 22279c44183a9c71301c770c4275545500a48345.

Change-Id: I7412de8381c38057fd40aa6e22f4829557478185