### PR TITLE
sensorservice: Register orientation sensor if HAL doesn't provide it

### DIFF
--- a/services/sensorservice/SensorService.cpp
+++ b/services/sensorservice/SensorService.cpp
@@ -191,9 +191,10 @@ void SensorService::onFirstRef() {
                 // available in the HAL
                 bool needRotationVector =
                         (virtualSensorsNeeds & (1<<SENSOR_TYPE_ROTATION_VECTOR)) != 0;
+                bool needOrientation = !needRotationVector && orientationIndex == -1;
 
                 registerSensor(new RotationVectorSensor(), !needRotationVector, true);
-                registerSensor(new OrientationSensor(), !needRotationVector, true);
+                registerSensor(new OrientationSensor(), !needOrientation, true);
 
                 bool needLinearAcceleration =
                         (virtualSensorsNeeds & (1<<SENSOR_TYPE_LINEAR_ACCELERATION)) != 0;


### PR DESCRIPTION
 * In KitKat and on most Samsung devices, the orientation sensor is
   not getting registered, and makes the compass non-working in a lot
   of apps. This patch enables the sensor for such devices.

Change-Id: I0ebba72ec4aa2cfa02c21a6daff0c356c6793fd0
(cherry picked from commit 98fa6f1152da759ef3eaf36cb16e0aaf2013376a)