### PR TITLE
SF: Improve hwrotation handling

### DIFF
--- a/services/surfaceflinger/DisplayDevice.h
+++ b/services/surfaceflinger/DisplayDevice.h
@@ -261,6 +261,8 @@ private:
     int mPowerMode;
     // Current active config
     int mActiveConfig;
+    // Panel hardware rotation
+    int32_t mHardwareRotation;
     // Panel's mount flip, H, V or 180 (HV)
     uint32_t mPanelMountFlip;
 #ifdef USE_HWC2

--- a/services/surfaceflinger/SurfaceFlinger.h
+++ b/services/surfaceflinger/SurfaceFlinger.h
@@ -601,6 +601,9 @@ private:
     bool mPrimaryHWVsyncEnabled;
     bool mHWVsyncAvailable;
 
+    // Panel hardware rotation
+    int32_t mHardwareRotation;
+
     /* ------------------------------------------------------------------------
      * Feature prototyping
      */

--- a/services/surfaceflinger/SurfaceFlinger_hwc1.cpp
+++ b/services/surfaceflinger/SurfaceFlinger_hwc1.cpp
@@ -199,6 +199,10 @@ SurfaceFlinger::SurfaceFlinger()
     property_get("debug.sf.disable_hwc_vds", value, "0");
     mUseHwcVirtualDisplays = !atoi(value);
     ALOGI_IF(!mUseHwcVirtualDisplays, "Disabling HWC virtual displays");
+
+    // we store the value as orientation:
+    // 90 -> 1, 180 -> 2, 270 -> 3
+    mHardwareRotation = property_get_int32("ro.sf.hwrotation", 0) / 90;
 }
 
 void SurfaceFlinger::onFirstRef()
@@ -671,16 +675,13 @@ status_t SurfaceFlinger::getDisplayConfigs(const sp<IBinder>& display,
             info.orientation = 0;
         }
 
-        char value[PROPERTY_VALUE_MAX];
-        property_get("ro.sf.hwrotation", value, "0");
-        int additionalRot = atoi(value) / 90;
-        if ((type == DisplayDevice::DISPLAY_PRIMARY) && (additionalRot & DisplayState::eOrientationSwapMask)) {
+        if ((type == DisplayDevice::DISPLAY_PRIMARY) &&
+                (mHardwareRotation & DisplayState::eOrientationSwapMask)) {
             info.h = hwConfig.width;
             info.w = hwConfig.height;
             info.xdpi = ydpi;
             info.ydpi = xdpi;
-        }
-        else {
+        } else {
             info.w = hwConfig.width;
             info.h = hwConfig.height;
             info.xdpi = xdpi;


### PR DESCRIPTION
Avoid getprop() calls in performance critical display
code paths.
Instead of querying the property each time we need it,
we read it once during initialization and then reuse
the cached value.

This is more appropriate here because we do not expect
the value to change at runtime. In fact, this property
behaves like a compile time constant in the real world:
Set it once and never again (because the angle of your
panel is fixed and does not change after the device
leaves the factory).

Change-Id: I55c4131735a65c7bdde8b00c166913bffa6c4ec3