### PR TITLE
native: Increase ART heap limit to 192MB for 1024MB RAM devices

### DIFF
--- a/build/phone-xhdpi-1024-dalvik-heap.mk
+++ b/build/phone-xhdpi-1024-dalvik-heap.mk
@@ -18,7 +18,7 @@
 
 PRODUCT_PROPERTY_OVERRIDES += \
     dalvik.vm.heapstartsize=8m \
-    dalvik.vm.heapgrowthlimit=96m \
+    dalvik.vm.heapgrowthlimit=192m \
     dalvik.vm.heapsize=256m \
     dalvik.vm.heaptargetutilization=0.75 \
     dalvik.vm.heapminfree=2m \

--- a/build/tablet-7in-hdpi-1024-dalvik-heap.mk
+++ b/build/tablet-7in-hdpi-1024-dalvik-heap.mk
@@ -18,7 +18,7 @@
 
 PRODUCT_PROPERTY_OVERRIDES += \
     dalvik.vm.heapstartsize=8m \
-    dalvik.vm.heapgrowthlimit=80m \
+    dalvik.vm.heapgrowthlimit=192m \
     dalvik.vm.heapsize=384m \
     dalvik.vm.heaptargetutilization=0.75 \
     dalvik.vm.heapminfree=512k \


### PR DESCRIPTION
 * Needed for Google SetupWizard to start

 * Without this, SetupWizard is compiled by ART on boot
   and runs out of memory (heap) while running, resulting
   in the SetupWizard crashing and blocking boot

Change-Id: Ic5b8caf4352f6d104af9121a09a01adad1c5bcc3
Signed-off-by: Adrian DC <radian.dc@gmail.com>